### PR TITLE
Fix typo

### DIFF
--- a/text/locale/ar/LC_MESSAGES/components/packages/msl.po
+++ b/text/locale/ar/LC_MESSAGES/components/packages/msl.po
@@ -139,7 +139,7 @@ msgid "Integration and differentiation blocks"
 msgstr ""
 
 #: ../../source/components/packages/msl.rst:163
-msgid "Deadband and hyteresis blocks"
+msgid "Deadband and hysteresis blocks"
 msgstr ""
 
 #: ../../source/components/packages/msl.rst:164

--- a/text/locale/cn/LC_MESSAGES/components/packages/msl.po
+++ b/text/locale/cn/LC_MESSAGES/components/packages/msl.po
@@ -155,7 +155,7 @@ msgid "Integration and differentiation blocks"
 msgstr "积分与微分模块"
 
 #: ../../source/components/packages/msl.rst:163
-msgid "Deadband and hyteresis blocks"
+msgid "Deadband and hysteresis blocks"
 msgstr "死区以及滞回模块"
 
 #: ../../source/components/packages/msl.rst:164

--- a/text/locale/de/LC_MESSAGES/components/packages/msl.po
+++ b/text/locale/de/LC_MESSAGES/components/packages/msl.po
@@ -131,7 +131,7 @@ msgid "Integration and differentiation blocks"
 msgstr ""
 
 #: ../../source/components/packages/msl.rst:163
-msgid "Deadband and hyteresis blocks"
+msgid "Deadband and hysteresis blocks"
 msgstr ""
 
 #: ../../source/components/packages/msl.rst:164

--- a/text/locale/es/LC_MESSAGES/components/packages/msl.po
+++ b/text/locale/es/LC_MESSAGES/components/packages/msl.po
@@ -131,7 +131,7 @@ msgid "Integration and differentiation blocks"
 msgstr ""
 
 #: ../../source/components/packages/msl.rst:163
-msgid "Deadband and hyteresis blocks"
+msgid "Deadband and hysteresis blocks"
 msgstr ""
 
 #: ../../source/components/packages/msl.rst:164

--- a/text/locale/fr/LC_MESSAGES/components/packages/msl.po
+++ b/text/locale/fr/LC_MESSAGES/components/packages/msl.po
@@ -131,7 +131,7 @@ msgid "Integration and differentiation blocks"
 msgstr ""
 
 #: ../../source/components/packages/msl.rst:163
-msgid "Deadband and hyteresis blocks"
+msgid "Deadband and hysteresis blocks"
 msgstr ""
 
 #: ../../source/components/packages/msl.rst:164

--- a/text/locale/it/LC_MESSAGES/components/packages/msl.po
+++ b/text/locale/it/LC_MESSAGES/components/packages/msl.po
@@ -131,7 +131,7 @@ msgid "Integration and differentiation blocks"
 msgstr ""
 
 #: ../../source/components/packages/msl.rst:163
-msgid "Deadband and hyteresis blocks"
+msgid "Deadband and hysteresis blocks"
 msgstr ""
 
 #: ../../source/components/packages/msl.rst:164

--- a/text/locale/kr/LC_MESSAGES/components/packages/msl.po
+++ b/text/locale/kr/LC_MESSAGES/components/packages/msl.po
@@ -139,7 +139,7 @@ msgid "Integration and differentiation blocks"
 msgstr ""
 
 #: ../../source/components/packages/msl.rst:163
-msgid "Deadband and hyteresis blocks"
+msgid "Deadband and hysteresis blocks"
 msgstr ""
 
 #: ../../source/components/packages/msl.rst:164

--- a/text/locale/pt_BR/LC_MESSAGES/components/packages/msl.po
+++ b/text/locale/pt_BR/LC_MESSAGES/components/packages/msl.po
@@ -139,7 +139,7 @@ msgid "Integration and differentiation blocks"
 msgstr ""
 
 #: ../../source/components/packages/msl.rst:163
-msgid "Deadband and hyteresis blocks"
+msgid "Deadband and hysteresis blocks"
 msgstr ""
 
 #: ../../source/components/packages/msl.rst:164

--- a/text/source/components/packages/msl.rst
+++ b/text/source/components/packages/msl.rst
@@ -160,7 +160,7 @@ components that can be found in this library include:
   * Output connectors (``Real``, ``Integer`` and ``Boolean``)
   * Gain block, summation blocks, product blocks
   * Integration and differentiation blocks
-  * Deadband and hyteresis blocks
+  * Deadband and hysteresis blocks
   * Logic and relational operation blocks
   * Mux and demux blocks
 


### PR DESCRIPTION
Just a tiny typo: it should be hysteresis instead of hyteresis. 
It should be fixed in the translations, too.