### PR TITLE
Add initial_population variable to start value of population

### DIFF
--- a/ModelicaByExample/Components/LotkaVolterra/Components/RegionalPopulation.mo
+++ b/ModelicaByExample/Components/LotkaVolterra/Components/RegionalPopulation.mo
@@ -13,7 +13,7 @@ model RegionalPopulation "Population of animals in a specific region"
     annotation (Placement(transformation(extent={{-10,90},{10,110}}),
         iconTransformation(extent={{-10,90},{10,110}})));
 protected
-  Real population(start=10) = species.population "Population in this region";
+  Real population(start=initial_population) = species.population "Population in this region";
 initial equation
   if init==InitializationOptions.FixedPopulation then
     population = initial_population;


### PR DESCRIPTION
The `ThreeSpecies_Quiescent` example seems to be broken using `OpenModelica v1.24.0-dev-164-g537f41ed82`, probably due to the changes to the `Protected` section of models in Modelica, see #453. This PR suggests a solution by adjusting the start value.

The population variable is protected and setting the start value only works when using the `FixedPopulation` initialization, then it is set using:

https://github.com/mtiller/ModelicaBook/blob/b07a59eb08814a1be48ddf30e70a36cef4ee6835/ModelicaByExample/Components/LotkaVolterra/Components/RegionalPopulation.mo#L18-L19

When using `InitializationOptions.SteadyState`, the start value is not adjusted and the trivial solution is found instead of the non-zero solution.

Only the derivative is adjusted:

https://github.com/mtiller/ModelicaBook/blob/b07a59eb08814a1be48ddf30e70a36cef4ee6835/ModelicaByExample/Components/LotkaVolterra/Components/RegionalPopulation.mo#L20-L21

And for the start guess, the following line is still used:

https://github.com/mtiller/ModelicaBook/blob/b07a59eb08814a1be48ddf30e70a36cef4ee6835/ModelicaByExample/Components/LotkaVolterra/Components/RegionalPopulation.mo#L16

With the following change, all examples seem to work correctly for me:

```Modelica
Real population(start=initial_population)
```
